### PR TITLE
voting-app-result-nodejs-stateful to 0.0.16

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.1
 - name: voting-app-result-nodejs-stateful
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.16
 - name: voting-app-worker-java-2stateful
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.5


### PR DESCRIPTION
Promote voting-app-result-nodejs-stateful to version 0.0.16